### PR TITLE
fix: update actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/aws-apply.yml
+++ b/.github/workflows/aws-apply.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # ── 1. Checkout this repo (with private submodules) ──────────────
       - name: Checkout GitOps
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_PAT }}
           submodules: recursive
@@ -43,7 +43,7 @@ jobs:
 
       # ── 2. Checkout GitOps-Secrets ────────────────────────────────────
       - name: Checkout GitOps-Secrets
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: DAWS25/GitOps-Secrets
           token: ${{ secrets.GH_PAT }}
@@ -51,7 +51,7 @@ jobs:
 
       # ── 3. AWS credentials via OIDC ───────────────────────────────────
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` v4 → v6 (Node.js 24 runtime)
- Bumps `aws-actions/configure-aws-credentials` v4 → v6 (Node.js 24 runtime)
- `aws-actions/setup-sam` stays at v2 (latest available)

Fixes the Node.js 20 deprecation warnings from the dry-run on 2026-04-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)