### PR TITLE
fix: opt into Node.js 24 for setup-sam action

### DIFF
--- a/.github/workflows/aws-apply.yml
+++ b/.github/workflows/aws-apply.yml
@@ -24,6 +24,8 @@ jobs:
   aws-apply:
     runs-on: ubuntu-latest
     environment: production
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       # ── 1. Checkout this repo (with private submodules) ──────────────


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the job level
- Silences the remaining Node.js 20 deprecation warning from `aws-actions/setup-sam@v2`, which has no Node.js 24-native release yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)