### PR TITLE
fix: install Python 3.14 for Presence SAM Lambda runtime

### DIFF
--- a/.github/workflows/aws-apply.yml
+++ b/.github/workflows/aws-apply.yml
@@ -58,7 +58,13 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
-      # ── 4. Install AWS SAM CLI (used by Presence after-hooks) ─────────
+      # ── 4. Python 3.14 (required by Presence SAM Lambda runtime) ────────
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      # ── 5. Install AWS SAM CLI (used by Presence after-hooks) ─────────
       - name: Install AWS SAM CLI
         uses: aws-actions/setup-sam@v2
         with:


### PR DESCRIPTION
## Summary
- Adds `actions/setup-python@v5` step to install Python 3.14 before `sam build`
- Fixes: `PythonPipBuilder:Validation - Binary validation failed ... runtime: python3.14`

The Presence SAM function specifies `python3.14` as its Lambda runtime. The `ubuntu-latest` runner does not ship Python 3.14, causing `sam build` (invoked from the `Presence-bucket-webapp` after-hook) to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)