### PR TITLE
fix: Node.js 24 compatibility, Python 3.14 for SAM runtime

### DIFF
--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -36,6 +36,7 @@
         "ms-azuretools.vscode-docker",
         "github.copilot",
         "github.copilot-chat",
+        "github.vscode-github-actions",
         "vscjava.vscode-java-pack",
         "vscjava.vscode-java-debug",
         "vscjava.vscode-java-dependency",


### PR DESCRIPTION
## Summary

- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` so third-party actions run under Node.js 24 instead of the deprecated Node.js 16/20
- Add `actions/setup-python@v5` step to install Python 3.14, required by the Presence SAM Lambda runtime
- Add `github.vscode-github-actions` extension to the Codespaces devcontainer for better workflow editing

## Test plan

- [ ] Merge to main and observe the `aws-apply` workflow run completes successfully without Node.js deprecation warnings
- [ ] Confirm SAM CLI install step succeeds with Python 3.14 available

🤖 Generated with [Claude Code](https://claude.com/claude-code)