### PR TITLE
feat: add Google Cloud CLI to devcontainer

### DIFF
--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -7,7 +7,8 @@
 
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/gcloud-cli:1": {}
   },
 
   "postCreateCommand": "./.devcontainer/codespaces/post-create.sh",


### PR DESCRIPTION
## Summary

- Adds `ghcr.io/devcontainers/features/gcloud-cli:1` feature to the Codespaces devcontainer

## Test plan

- [ ] Rebuild devcontainer and verify `gcloud version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)